### PR TITLE
New params

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,10 @@ phraseapp {
 
     // If you want to omit translation comments imported by the download task. Default: false
     ignoreComments.set(false)
+
+    // If you want to import only some locales during the download task. Skip param to fetch all locales.
+    // For example: ['cs-CZ', 'fr-FR', 'de-DE']
+    allowedLocaleCodes.set(listOf("<locale_code>"))
 }
 ```
 
@@ -151,6 +155,10 @@ phraseapp {
 
     // If you want to omit translation comments imported by the download task. Default: false
     ignoreComments = false
+
+    // If you want to import only some locales during the download task. Skip param to fetch all locales.
+    // For example: ['cs-CZ', 'fr-FR', 'de-DE']
+    allowedLocaleCodes = ["<locale_code>"]
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -115,6 +115,9 @@ phraseapp {
 
     // If you want to specify your custom locale in the name of a PhraseApp locale, you can specify the regex of your PhraseApp locale name here. Default: .+_([a-z]{2}-[A-Z]{2})
     localeNameRegex.set("<string>")
+
+    // If you want to omit translation comments imported by the download task. Default: false
+    ignoreComments.set(false)
 }
 ```
 
@@ -145,6 +148,9 @@ phraseapp {
 
     // If you want to specify your custom locale in the name of a PhraseApp locale, you can specify the regex of your PhraseApp locale name here. Default: .+_([a-z]{2}-[A-Z]{2})
     localeNameRegex = "<string>"
+
+    // If you want to omit translation comments imported by the download task. Default: false
+    ignoreComments = false
 }
 ```
 

--- a/api-gradle/src/main/kotlin/phraseapp/DownloadTask.kt
+++ b/api-gradle/src/main/kotlin/phraseapp/DownloadTask.kt
@@ -3,6 +3,7 @@ package phraseapp
 import kotlinx.coroutines.runBlocking
 import org.gradle.api.DefaultTask
 import org.gradle.api.GradleException
+import org.gradle.api.provider.ListProperty
 import org.gradle.api.provider.MapProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Input
@@ -47,11 +48,15 @@ abstract class DownloadTask : DefaultTask() {
     @get:Input
     abstract val ignoreComments: Property<Boolean>
 
+    @get:Input
+    abstract val allowedLocaleCodes: ListProperty<String>
+
     init {
         overrideDefaultFile.convention(false)
         exceptions.convention(emptyMap())
         placeholder.convention(false)
         ignoreComments.convention(false)
+        allowedLocaleCodes.convention(emptyList())
     }
 
     @TaskAction
@@ -71,7 +76,8 @@ abstract class DownloadTask : DefaultTask() {
                     exceptions.get(),
                     placeholder.get(),
                     localeNameRegex.get(),
-                    ignoreComments.get()
+                    ignoreComments.get(),
+                    allowedLocaleCodes.get()
                 )
             logger.info("All resources have been printed!")
         } catch (error: Throwable) {

--- a/api-gradle/src/main/kotlin/phraseapp/DownloadTask.kt
+++ b/api-gradle/src/main/kotlin/phraseapp/DownloadTask.kt
@@ -44,10 +44,14 @@ abstract class DownloadTask : DefaultTask() {
     @get:Input
     abstract val placeholder: Property<Boolean>
 
+    @get:Input
+    abstract val ignoreComments: Property<Boolean>
+
     init {
         overrideDefaultFile.convention(false)
         exceptions.convention(emptyMap())
         placeholder.convention(false)
+        ignoreComments.convention(false)
     }
 
     @TaskAction
@@ -66,7 +70,8 @@ abstract class DownloadTask : DefaultTask() {
                     overrideDefaultFile.get(),
                     exceptions.get(),
                     placeholder.get(),
-                    localeNameRegex.get()
+                    localeNameRegex.get(),
+                    ignoreComments.get()
                 )
             logger.info("All resources have been printed!")
         } catch (error: Throwable) {

--- a/api-gradle/src/main/kotlin/phraseapp/PhraseAppPlugin.kt
+++ b/api-gradle/src/main/kotlin/phraseapp/PhraseAppPlugin.kt
@@ -25,6 +25,7 @@ class PhraseAppPlugin : Plugin<Project> {
                     exceptions.set(phraseapp.exceptions.get())
                     placeholder.set(phraseapp.placeholder.get())
                     localeNameRegex.set(phraseapp.localeNameRegex.get())
+                    ignoreComments.set(phraseapp.ignoreComments.get())
                     description = "Download translations from the source set to PhraseApp"
                 }
 

--- a/api-gradle/src/main/kotlin/phraseapp/PhraseAppPlugin.kt
+++ b/api-gradle/src/main/kotlin/phraseapp/PhraseAppPlugin.kt
@@ -26,6 +26,7 @@ class PhraseAppPlugin : Plugin<Project> {
                     placeholder.set(phraseapp.placeholder.get())
                     localeNameRegex.set(phraseapp.localeNameRegex.get())
                     ignoreComments.set(phraseapp.ignoreComments.get())
+                    allowedLocaleCodes.set(phraseapp.allowedLocaleCodes.get())
                     description = "Download translations from the source set to PhraseApp"
                 }
 

--- a/api-gradle/src/main/kotlin/phraseapp/PhraseappPluginExtension.kt
+++ b/api-gradle/src/main/kotlin/phraseapp/PhraseappPluginExtension.kt
@@ -7,6 +7,7 @@ import org.gradle.api.provider.MapProperty
 import org.gradle.api.provider.Property
 import phraseapp.internal.Platform
 import phraseapp.network.*
+import phraseapp.parsers.xml.DEFAULT_IGNORE_COMMENTS
 
 fun Project.phraseapp(configure: Action<PhraseappPluginExtension>): Unit
     = extensions.configure("phraseapp", configure)
@@ -83,6 +84,10 @@ abstract class PhraseappPluginExtension {
      * specify the regex of your PhraseApp locale name here. Default: .+_([a-z]{2}-[A-Z]{2})
      */
     abstract val localeNameRegex: Property<String>
+    /**
+     * If you want to omit comments in translation files. Default: false
+     */
+    abstract val ignoreComments: Property<Boolean>
 
     init {
         resFolder.convention("")
@@ -94,5 +99,6 @@ abstract class PhraseappPluginExtension {
         exceptions.convention(DEFAULT_EXCEPTIONS)
         placeholder.convention(DEFAULT_PLACEHOLDER)
         localeNameRegex.convention(DEFAULT_REGEX)
+        ignoreComments.convention(DEFAULT_IGNORE_COMMENTS)
     }
 }

--- a/api-gradle/src/main/kotlin/phraseapp/PhraseappPluginExtension.kt
+++ b/api-gradle/src/main/kotlin/phraseapp/PhraseappPluginExtension.kt
@@ -88,6 +88,11 @@ abstract class PhraseappPluginExtension {
      * If you want to omit comments in translation files. Default: false
      */
     abstract val ignoreComments: Property<Boolean>
+    /**
+     * If you want to import only some locales during the download task. Skip param to fetch all locales.
+     * For example: ['cs-CZ', 'fr-FR', 'de-DE']
+     */
+    abstract val allowedLocaleCodes: ListProperty<String>
 
     init {
         resFolder.convention("")
@@ -100,5 +105,6 @@ abstract class PhraseappPluginExtension {
         placeholder.convention(DEFAULT_PLACEHOLDER)
         localeNameRegex.convention(DEFAULT_REGEX)
         ignoreComments.convention(DEFAULT_IGNORE_COMMENTS)
+        allowedLocaleCodes.convention(DEFAULT_ALLOWED_LOCALE_CODES)
     }
 }

--- a/client/src/main/kotlin/phraseapp/extensions/StringExtensions.kt
+++ b/client/src/main/kotlin/phraseapp/extensions/StringExtensions.kt
@@ -13,23 +13,23 @@ fun String.writeTo(outputTargetFile: String) {
     outputFile.writeText(text = this)
 }
 
-fun String.parse(file: File): ResourceTranslation {
+fun String.parse(file: File, ignoreComments: Boolean = false): ResourceTranslation {
     return if (file.absolutePath.contains(".arb")) {
         parseArb()
     } else {
-        parseXML()
+        parseXML(ignoreComments)
     }
 }
 
-fun String.parse(format: String): ResourceTranslation {
+fun String.parse(format: String, ignoreComments: Boolean = false): ResourceTranslation {
     return if (format.equals("arb")) {
         parseArb()
     } else {
-        parseXML()
+        parseXML(ignoreComments)
     }
 }
 
-private fun String.parseXML(): ResourceTranslation {
+private fun String.parseXML(ignoreComments: Boolean): ResourceTranslation {
     val content = this
         .replace("&amp;", "[[MARKER]]&amp;[[MARKER]]")
         .replace("&lt;", "[[MARKER]]&lt;[[MARKER]]")
@@ -40,7 +40,7 @@ private fun String.parseXML(): ResourceTranslation {
         .replace("<!\\[CDATA\\[(.*)]]>".toRegex()) { "&lt;![CDATA[${it.groups[it.groups.size - 1]!!.value}]]&gt;" }
         .replace("<(?!(/)?resources|(/)?string|(/)?plurals|(/)?string-array|(/)?item|\\?xml|!--)([^>]*)>".toRegex()) { "&lt;${it.groups[it.groups.size - 1]!!.value}&gt;" }
     val resources = try {
-        XmlParser(xml = content).document["resources"][0]
+        XmlParser(xml = content, ignoreComments).document["resources"][0]
     } catch (e: Throwable) {
         throw e
     }

--- a/client/src/main/kotlin/phraseapp/network/PhraseAppNetworkDataSource.kt
+++ b/client/src/main/kotlin/phraseapp/network/PhraseAppNetworkDataSource.kt
@@ -12,6 +12,7 @@ const val DEFAULT_REGEX = ".+_([a-z]{2}-[A-Z]{2})"
 const val DEFAULT_PLACEHOLDER = false
 val DEFAULT_EXCEPTIONS: Map<String, String> = emptyMap()
 const val DEFAULT_OVERRIDE_DEFAULT_FILE = false
+val DEFAULT_ALLOWED_LOCALE_CODES: List<String> = emptyList()
 const val PHRASEAPP_BASEURL = "https://api.phrase.com/api/"
 
 data class LocaleContent(val content: String, val isDefault: Boolean)
@@ -21,7 +22,8 @@ interface PhraseAppNetworkDataSource {
         overrideDefaultFile: Boolean = DEFAULT_OVERRIDE_DEFAULT_FILE,
         exceptions: Map<String, String> = DEFAULT_EXCEPTIONS,
         placeHolder: Boolean = DEFAULT_PLACEHOLDER,
-        localeNameRegex: String = DEFAULT_REGEX
+        localeNameRegex: String = DEFAULT_REGEX,
+        allowedLocaleCodes: List<String> = DEFAULT_ALLOWED_LOCALE_CODES
     ): Map<String, LocaleContent>
 
     suspend fun upload(localeId: String, filePath: String)

--- a/client/src/main/kotlin/phraseapp/network/PhraseAppNetworkDataSourceImpl.kt
+++ b/client/src/main/kotlin/phraseapp/network/PhraseAppNetworkDataSourceImpl.kt
@@ -25,11 +25,15 @@ class PhraseAppNetworkDataSourceImpl(
         overrideDefaultFile: Boolean,
         exceptions: Map<String, String>,
         placeHolder: Boolean,
-        localeNameRegex: String
+        localeNameRegex: String,
+        allowedLocaleCodes: List<String>
     ): Map<String, LocaleContent> = coroutineScope {
         val namePattern = Pattern.compile(localeNameRegex)
         val locales = service.getLocales(token, projectId)
-            .filter { it.isDefault.not() or overrideDefaultFile }
+            .filter {
+                (it.isDefault.not() or overrideDefaultFile) &&
+                        (allowedLocaleCodes.isEmpty() || allowedLocaleCodes.contains(it.code))
+            }
         val chunked = locales.chunked(CONCURRENT_LIMIT)
         val localesResponse = iterative(chunked, THROTTLING_LIMIT, placeHolder)
         return@coroutineScope localesResponse

--- a/client/src/main/kotlin/phraseapp/parsers/xml/XmlParser.kt
+++ b/client/src/main/kotlin/phraseapp/parsers/xml/XmlParser.kt
@@ -1,18 +1,19 @@
 package phraseapp.parsers.xml
 
 import org.w3c.dom.Document
-import org.xml.sax.InputSource
 import java.io.InputStream
 import javax.xml.parsers.DocumentBuilderFactory
 
-class XmlParser(stream: InputStream) {
-    constructor(xml: String) : this(xml.byteInputStream())
+const val DEFAULT_IGNORE_COMMENTS = false
+
+class XmlParser(stream: InputStream, ignoreComments: Boolean = DEFAULT_IGNORE_COMMENTS) {
+    constructor(xml: String, ignoreComments: Boolean = DEFAULT_IGNORE_COMMENTS) : this(xml.byteInputStream(), ignoreComments)
 
     val document: Document
 
     init {
         val documentFactory = DocumentBuilderFactory.newInstance().apply {
-            isIgnoringComments = false
+            isIgnoringComments = ignoreComments
         }
         document = documentFactory.newDocumentBuilder().parse(stream)
         document.documentElement.normalize()

--- a/client/src/main/kotlin/phraseapp/repositories/operations/Downloader.kt
+++ b/client/src/main/kotlin/phraseapp/repositories/operations/Downloader.kt
@@ -26,10 +26,17 @@ class Downloader(
         exceptions: Map<String, String> = DEFAULT_EXCEPTIONS,
         placeholder: Boolean = DEFAULT_PLACEHOLDER,
         localeNameRegex: String = DEFAULT_REGEX,
-        ignoreComments: Boolean = DEFAULT_IGNORE_COMMENTS
+        ignoreComments: Boolean = DEFAULT_IGNORE_COMMENTS,
+        allowedLocaleCodes: List<String> = DEFAULT_ALLOWED_LOCALE_CODES
     ) = coroutineScope {
         val strings = localHelper.getStringsFileByResFolder(resFolders)
-        val locales = network.downloadAllLocales(overrideDefaultFile, exceptions, placeholder, localeNameRegex)
+        val locales = network.downloadAllLocales(
+            overrideDefaultFile,
+            exceptions,
+            placeholder,
+            localeNameRegex,
+            allowedLocaleCodes
+        )
         val resources = reducerHelper.reduceKeysForAllStringsFilesAndForAllLocales(strings, locales, ignoreComments)
         printerHelper.printResources(resources)
         printerHelper.printLocales(getTypes(resources))

--- a/client/src/main/kotlin/phraseapp/repositories/operations/Downloader.kt
+++ b/client/src/main/kotlin/phraseapp/repositories/operations/Downloader.kt
@@ -5,6 +5,7 @@ import phraseapp.internal.platforms.Platform
 import phraseapp.internal.printers.FileOperation
 import phraseapp.internal.xml.Resource
 import phraseapp.network.*
+import phraseapp.parsers.xml.DEFAULT_IGNORE_COMMENTS
 import phraseapp.repositories.operations.helpers.LocalHelper
 import phraseapp.repositories.operations.helpers.PrinterHelper
 import phraseapp.repositories.operations.helpers.ReducerHelper
@@ -24,11 +25,12 @@ class Downloader(
         overrideDefaultFile: Boolean = DEFAULT_OVERRIDE_DEFAULT_FILE,
         exceptions: Map<String, String> = DEFAULT_EXCEPTIONS,
         placeholder: Boolean = DEFAULT_PLACEHOLDER,
-        localeNameRegex: String = DEFAULT_REGEX
+        localeNameRegex: String = DEFAULT_REGEX,
+        ignoreComments: Boolean = DEFAULT_IGNORE_COMMENTS
     ) = coroutineScope {
         val strings = localHelper.getStringsFileByResFolder(resFolders)
         val locales = network.downloadAllLocales(overrideDefaultFile, exceptions, placeholder, localeNameRegex)
-        val resources = reducerHelper.reduceKeysForAllStringsFilesAndForAllLocales(strings, locales)
+        val resources = reducerHelper.reduceKeysForAllStringsFilesAndForAllLocales(strings, locales, ignoreComments)
         printerHelper.printResources(resources)
         printerHelper.printLocales(getTypes(resources))
         return@coroutineScope resources

--- a/client/src/test/kotlin/phraseapp/network/PhraseAppNetworkDataSourceTest.kt
+++ b/client/src/test/kotlin/phraseapp/network/PhraseAppNetworkDataSourceTest.kt
@@ -63,6 +63,14 @@ class PhraseAppNetworkDataSourceTest {
     }
 
     @Test
+    fun shouldSkipLocaleWhenLocaleCodeNotAllowed() = runBlocking {
+        val networkDataSource = PhraseAppNetworkDataSourceImpl("", "", "", service)
+        val xmlContents = networkDataSource.downloadAllLocales(allowedLocaleCodes = listOf("fr-FR"))
+        assertEquals(1, xmlContents.size)
+        assertTrue(xmlContents.containsKey("fr-FR"))
+    }
+
+    @Test
     fun shouldRedirectLocaleToNewLocaleNameWhenItIsPresentInExceptionList() = runBlocking {
         val networkDataSource = PhraseAppNetworkDataSourceImpl("", "", "", service)
         val xmlContents = networkDataSource.downloadAllLocales(exceptions = mapOf("es-ES" to "ca-ES"))

--- a/client/src/test/kotlin/phraseapp/parsers/xml/XmlParserTest.kt
+++ b/client/src/test/kotlin/phraseapp/parsers/xml/XmlParserTest.kt
@@ -2,6 +2,7 @@ package phraseapp.parsers.xml
 
 import assertk.assertions.containsAll
 import assertk.assertions.isEqualTo
+import assertk.assertions.isNull
 import assertk.assertions.isTrue
 import org.junit.Test
 
@@ -55,6 +56,19 @@ class XmlParserTest {
         val document = XmlParser(xml).document
         val string = document["resources"][0].childs[0]
         assertk.assert(string.comment).isEqualTo("Hello, World!")
+    }
+
+    @Test
+    fun shouldNotGetCommentsIfIgnored() {
+        val xml = """
+<resources>
+    <!-- Hello, World! -->
+    <string name="hello">Hello, World!</string>
+</resources>
+""".trimIndent()
+        val document = XmlParser(xml, ignoreComments = true).document
+        val string = document["resources"][0].childs[0]
+        assertk.assert(string.comment).isNull()
     }
 
     @Test

--- a/client/src/test/kotlin/phraseapp/repositories/checks/CheckRepositoryTest.kt
+++ b/client/src/test/kotlin/phraseapp/repositories/checks/CheckRepositoryTest.kt
@@ -18,7 +18,7 @@ class CheckRepositoryTest {
     @Test
     fun shouldGetFilePrintedInPhraseAppOutputsWhenThereAreErrorsInChecks() = runBlocking {
         val phraseAppNetworkDataSource: PhraseAppNetworkDataSource = mock {
-            `when`(it.downloadAllLocales(any(), any(), any(), any())).thenReturn(mapOf(
+            `when`(it.downloadAllLocales(any(), any(), any(), any(), any())).thenReturn(mapOf(
                 "en" to LocaleContent(File("src/test/resources/android-errors/values/strings.xml").readText(), true),
                 "fr-FR" to LocaleContent(File("src/test/resources/android-errors/values-fr-rFR/strings.xml").readText(), false),
                 "es-ES" to LocaleContent(File("src/test/resources/android-errors/values-es-rES/strings.xml").readText(), false)
@@ -44,7 +44,7 @@ es-ES :: PLACEHOLDER :: hello
     @Test
     fun shouldNotGetErrorsWhenThereIsNoErrorInStringsFiles() = runBlocking {
         val phraseAppNetworkDataSource: PhraseAppNetworkDataSource = mock {
-            `when`(it.downloadAllLocales(any(), any(), any(), any())).thenReturn(mapOf(
+            `when`(it.downloadAllLocales(any(), any(), any(), any(), any())).thenReturn(mapOf(
                 "en" to LocaleContent(File("src/test/resources/android-local/values/strings.xml").readText(), true),
                 "fr-FR" to LocaleContent(File("src/test/resources/android-local/values-fr/strings.xml").readText(), false),
                 "es-ES" to LocaleContent(File("src/test/resources/android-local/values-es-rES/strings.xml").readText(), false)
@@ -59,7 +59,7 @@ es-ES :: PLACEHOLDER :: hello
     @Test
     fun shouldNotGetErrorWhenThereAreMissingTranslations() = runBlocking {
         val phraseAppNetworkDataSource: PhraseAppNetworkDataSource = mock {
-            `when`(it.downloadAllLocales(any(), any(), any(), any())).thenReturn(mapOf(
+            `when`(it.downloadAllLocales(any(), any(), any(), any(), any())).thenReturn(mapOf(
                 "en" to LocaleContent(File("src/test/resources/android/values/strings.xml").readText(), true),
                 "fr-FR" to LocaleContent(File("src/test/resources/android/values-fr-rFR/strings.xml").readText(), false)
             ))

--- a/client/src/test/kotlin/phraseapp/repositories/operations/helpers/ReducerHelperTest.kt
+++ b/client/src/test/kotlin/phraseapp/repositories/operations/helpers/ReducerHelperTest.kt
@@ -28,8 +28,9 @@ class ReducerHelperTest {
     fun testWhenThereIsNoStringsInRemote() {
         val helper = ReducerHelper(Android)
         val strings = helper.reduceKeysForAllStringsFilesAndForAllLocales(
-                mapOf(createStringsFile("src/test/resources/android")),
-                mapOf(createLocaleContent("en", EMPTY))
+            mapOf(createStringsFile("src/test/resources/android")),
+            mapOf(createLocaleContent("en", EMPTY)),
+            false
         )
         assertEquals(1, strings.keys.size)
         assertTrue(strings.containsKey("src/test/resources/android"))
@@ -43,8 +44,9 @@ class ReducerHelperTest {
     fun testWhenThereAreMoreStringsInRemoteThanLocal() {
         val helper = ReducerHelper(Android)
         val strings = helper.reduceKeysForAllStringsFilesAndForAllLocales(
-                mapOf(createStringsFile("src/test/resources/android")),
-                mapOf(createLocaleContent("fr-FR", EXAMPLE_1))
+            mapOf(createStringsFile("src/test/resources/android")),
+            mapOf(createLocaleContent("fr-FR", EXAMPLE_1)),
+            false
         )
         assertEquals(1, strings.keys.size)
         assertTrue(strings.containsKey("src/test/resources/android"))
@@ -58,8 +60,12 @@ class ReducerHelperTest {
     fun testWhenThereAreMultipleResFolders() {
         val helper = ReducerHelper(Android)
         val strings = helper.reduceKeysForAllStringsFilesAndForAllLocales(
-                mapOf(createStringsFile("src/test/resources/android"), createStringsFile("src/test/resources/android-local")),
-                mapOf(createLocaleContent("fr-FR", EXAMPLE_1))
+            mapOf(
+                createStringsFile("src/test/resources/android"),
+                createStringsFile("src/test/resources/android-local")
+            ),
+            mapOf(createLocaleContent("fr-FR", EXAMPLE_1)),
+            false
         )
         assertEquals(2, strings.keys.size)
         assertTrue(strings.keys.contains("src/test/resources/android"))


### PR DESCRIPTION
- added `ignoreComments` param to be able to disable translation comments downloaded via the `download` task
- added `allowedLocaleCodes` param to be able to filter only some locales by the locale code (i.e. `fr-FR`) downloaded via the `download` task