### PR TITLE
feat: Update maven-publish-plugin, gradle and kotlin versions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,16 +8,19 @@ allprojects {
 
 buildscript {
     ext.versions = [
-            'kotlin'       : '1.5.31',
+            'kotlin'       : '1.8.0',
             'coroutine'    : '1.5.2',
             'retrofit'     : '2.9.0',
             'okhttp'       : '4.9.1',
             'rxjava'       : '2.2.6',
             'gson'         : '2.8.6',
+            'maven'        : '0.25.1',
 
             'junit'        : '4.12',
             'mockito'      : '2.1.0',
-            'assertk'      : '0.9'
+            'assertk'      : '0.9',
+            'jacoco'       : '0.8.6',
+            'sonarqube'    : '2.8'
     ]
 
     ext.deps = [
@@ -46,10 +49,10 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath "org.sonarsource.scanner.gradle:sonarqube-gradle-plugin:2.8"
-        classpath "org.jacoco:org.jacoco.core:0.8.6"
+        classpath "org.sonarsource.scanner.gradle:sonarqube-gradle-plugin:${versions.sonarqube}"
+        classpath "org.jacoco:org.jacoco.core:${versions.jacoco}"
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:${versions.kotlin}"
-        classpath 'com.vanniktech:gradle-maven-publish-plugin:0.15.1'
+        classpath "com.vanniktech:gradle-maven-publish-plugin:${versions.maven}"
     }
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Mon Dec 28 10:00:20 PST 2015
+#Thu Mar 30 15:57:31 CEST 2023
 distributionBase=GRADLE_USER_HOME
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.0.2-bin.zip
 distributionPath=wrapper/dists
-zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-all.zip
+zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
- updated `maven-publish-plugin` to the latest version to avoid error while publishing to the local maven:
-- `Cannot perform signing task ':api-gradle:signPluginMavenPublication' because it has no configured signatory`
- required to also update kotlin and gradle versions
- moved remaining hardcoded versions to the `versions` variable