### PR TITLE
 feat: add RateLimitInterceptor + configurable maxConcurrentDownloads

### DIFF
--- a/api-gradle/src/main/kotlin/phrase/PhraseExtension.kt
+++ b/api-gradle/src/main/kotlin/phrase/PhraseExtension.kt
@@ -82,6 +82,12 @@ abstract class PhraseExtension {
      * For example: ['cs-CZ', 'fr-FR', 'de-DE']
      */
     abstract val allowedLocaleCodes: ListProperty<String>
+    /**
+     * Maximum number of concurrent download requests sent to the Phrase API.
+     * Lowering this value reduces the risk of hitting Phrase's concurrent request cap
+     * (HTTP 429) when several CI builds run in parallel. Default: 1.
+     */
+    abstract val maxConcurrentDownloads: Property<Int>
 
     init {
         resFolders.convention(arrayListOf())
@@ -94,5 +100,6 @@ abstract class PhraseExtension {
         localeNameRegex.convention(DEFAULT_REGEX)
         ignoreComments.convention(DEFAULT_IGNORE_COMMENTS)
         allowedLocaleCodes.convention(DEFAULT_ALLOWED_LOCALE_CODES)
+        maxConcurrentDownloads.convention(DEFAULT_MAX_CONCURRENT_DOWNLOADS)
     }
 }

--- a/api-gradle/src/main/kotlin/phrase/PhrasePlugin.kt
+++ b/api-gradle/src/main/kotlin/phrase/PhrasePlugin.kt
@@ -36,6 +36,7 @@ class PhrasePlugin : Plugin<Project> {
                     task.localeNameRegex.set(phrase.localeNameRegex.get())
                     task.ignoreComments.set(phrase.ignoreComments.get())
                     task.allowedLocaleCodes.set(phrase.allowedLocaleCodes.get())
+                    task.maxConcurrentDownloads.set(phrase.maxConcurrentDownloads.get())
                     task.description = "Download translations from the source set to PhraseApp"
                 }
 

--- a/api-gradle/src/main/kotlin/phrase/tasks/DownloadTask.kt
+++ b/api-gradle/src/main/kotlin/phrase/tasks/DownloadTask.kt
@@ -51,12 +51,16 @@ abstract class DownloadTask : DefaultTask() {
     @get:Input
     abstract val allowedLocaleCodes: ListProperty<String>
 
+    @get:Input
+    abstract val maxConcurrentDownloads: Property<Int>
+
     init {
         overrideDefaultFile.convention(false)
         exceptions.convention(emptyMap())
         placeholder.convention(false)
         ignoreComments.convention(false)
         allowedLocaleCodes.convention(emptyList())
+        maxConcurrentDownloads.convention(1)
     }
 
     @TaskAction
@@ -67,7 +71,8 @@ abstract class DownloadTask : DefaultTask() {
                 baseUrl.get(),
                 authToken.get(),
                 projectId.get(),
-                platform.get().format
+                platform.get().format,
+                maxConcurrentDownloads.get()
             )
             val fileOperation: FileOperation = FileOperationImpl()
             Downloader(platform.get(), output.get(), fileOperation, network)

--- a/client/build.gradle.kts
+++ b/client/build.gradle.kts
@@ -18,6 +18,8 @@ dependencies {
     testImplementation(libs.junit)
     testImplementation(libs.assertk)
     testImplementation(libs.mockito.kotlin)
+    testImplementation(libs.square.okhttp.mockwebserver)
+    testImplementation(libs.kotlinx.coroutines.test)
 }
 
 tasks.withType<KotlinCompile>().configureEach {

--- a/client/src/main/kotlin/phraseapp/network/PhraseAppNetworkDataSource.kt
+++ b/client/src/main/kotlin/phraseapp/network/PhraseAppNetworkDataSource.kt
@@ -14,6 +14,7 @@ val DEFAULT_EXCEPTIONS: Map<String, String> = emptyMap()
 const val DEFAULT_OVERRIDE_DEFAULT_FILE = false
 val DEFAULT_ALLOWED_LOCALE_CODES: List<String> = emptyList()
 const val PHRASEAPP_BASEURL = "https://api.phrase.com/api/"
+const val DEFAULT_MAX_CONCURRENT_DOWNLOADS = 1
 
 data class LocaleContent(val content: String, val isDefault: Boolean)
 
@@ -28,12 +29,18 @@ interface PhraseAppNetworkDataSource {
     suspend fun upload(localeId: String, filePath: String)
 
     companion object {
-        fun newInstance(baseUrl: String, token: String, projectId: String, fileFormat: String)
-                : PhraseAppNetworkDataSource {
+        fun newInstance(
+            baseUrl: String,
+            token: String,
+            projectId: String,
+            fileFormat: String,
+            maxConcurrentDownloads: Int = DEFAULT_MAX_CONCURRENT_DOWNLOADS
+        ): PhraseAppNetworkDataSource {
             val gson = GsonBuilder()
                 .setFieldNamingPolicy(FieldNamingPolicy.LOWER_CASE_WITH_UNDERSCORES)
                 .create()
             val client = OkHttpClient.Builder()
+                .addInterceptor(RateLimitInterceptor())
                 .addInterceptor(HttpLoggingInterceptor().setLevel(HttpLoggingInterceptor.Level.BODY))
                 .hostnameVerifier { _, _ -> true }
                 .build()
@@ -43,7 +50,11 @@ interface PhraseAppNetworkDataSource {
                 .addConverterFactory(GsonConverterFactory.create(gson))
                 .build()
             return PhraseAppNetworkDataSourceImpl(
-                token, projectId, fileFormat, retrofit.create(PhraseAppService::class.java)
+                token,
+                projectId,
+                fileFormat,
+                retrofit.create(PhraseAppService::class.java),
+                maxConcurrentDownloads
             )
         }
     }

--- a/client/src/main/kotlin/phraseapp/network/PhraseAppNetworkDataSourceImpl.kt
+++ b/client/src/main/kotlin/phraseapp/network/PhraseAppNetworkDataSourceImpl.kt
@@ -3,7 +3,8 @@ package phraseapp.network
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
-import kotlinx.coroutines.delay
+import kotlinx.coroutines.sync.Semaphore
+import kotlinx.coroutines.sync.withPermit
 import okhttp3.MediaType.Companion.toMediaTypeOrNull
 import okhttp3.MultipartBody.Companion.FORM
 import okhttp3.MultipartBody.Part
@@ -14,15 +15,16 @@ import java.util.regex.Pattern
 
 private class LocaleResponse(val locale: Locale, val content: String)
 
-const val CONCURRENT_LIMIT = 4
-const val THROTTLING_LIMIT = 500L
-
 class PhraseAppNetworkDataSourceImpl(
     private val token: String,
     private val projectId: String,
     private val fileFormat: String,
     private val service: PhraseAppService,
+    maxConcurrentDownloads: Int = DEFAULT_MAX_CONCURRENT_DOWNLOADS,
 ) : PhraseAppNetworkDataSource {
+
+    private val concurrencyLimit = maxConcurrentDownloads.coerceAtLeast(1)
+    private val semaphore = Semaphore(concurrencyLimit)
 
     override suspend fun downloadAllLocales(
         exceptions: Map<String, String>,
@@ -35,8 +37,32 @@ class PhraseAppNetworkDataSourceImpl(
             .filter {
                 (allowedLocaleCodes.isEmpty() || allowedLocaleCodes.contains(it.code))
             }
-        val chunked = locales.chunked(CONCURRENT_LIMIT)
-        val localesResponse = iterative(chunked, THROTTLING_LIMIT, placeHolder)
+        println("[PhraseAppNetwork] Downloading ${locales.size} locale(s) with concurrency=$concurrencyLimit")
+        val localesResponse = arrayListOf<LocaleResponse>()
+
+        // Process locales in chunks to avoid creating one coroutine per locale at once.
+        // This keeps roughly `concurrencyLimit` active coroutines and reduces memory/overhead.
+        for (chunk in locales.chunked(concurrencyLimit)) {
+            val chunkResults = chunk
+                .map { locale ->
+                    async {
+                        semaphore.withPermit {
+                            println("[PhraseAppNetwork] Downloading locale: id=${locale.id}, code=${locale.code}, name=${locale.name}, format=$fileFormat, placeHolder=$placeHolder")
+                            val file = service.download(
+                                token,
+                                projectId,
+                                locale.id,
+                                fileFormat,
+                                placeHolder
+                            )
+                            LocaleResponse(locale, file.string())
+                        }
+                    }
+                }
+                .awaitAll()
+
+            localesResponse.addAll(chunkResults)
+        }
         return@coroutineScope localesResponse
             .associate {
                 val phraseAppLocale = it.locale
@@ -46,35 +72,6 @@ class PhraseAppNetworkDataSourceImpl(
                 val key = exceptions.getOrDefault(code, code)
                 key to LocaleContent(it.content, it.locale.isDefault)
             }
-    }
-
-    private suspend fun iterative(
-        list: List<List<Locale>>,
-        onePerMillis: Long,
-        placeHolder: Boolean,
-    ) = coroutineScope<List<LocaleResponse>> {
-        val target = arrayListOf<LocaleResponse>()
-        for (item in list) {
-            target.addAll(
-                item
-                    .map { locale ->
-                        async {
-                            println("[PhraseAppNetwork] Downloading locale: id=${locale.id}, code=${locale.code}, name=${locale.name}, format=$fileFormat, placeHolder=$placeHolder")
-                            val file = service.download(
-                                token,
-                                projectId,
-                                locale.id,
-                                fileFormat,
-                                placeHolder
-                            )
-                            return@async LocaleResponse(locale, file.string())
-                        }
-                    }
-                    .awaitAll()
-            )
-            delay(onePerMillis)
-        }
-        return@coroutineScope target
     }
 
     override suspend fun upload(localeId: String, filePath: String) = coroutineScope {

--- a/client/src/main/kotlin/phraseapp/network/RateLimitInterceptor.kt
+++ b/client/src/main/kotlin/phraseapp/network/RateLimitInterceptor.kt
@@ -1,0 +1,116 @@
+package phraseapp.network
+
+import okhttp3.Interceptor
+import okhttp3.Response
+import kotlin.math.pow
+import kotlin.random.Random
+
+/**
+ * OkHttp interceptor that handles HTTP 429 responses from Phrase API.
+ *
+ * Phrase enforces two kinds of limits and signals them differently:
+ * - Concurrent request cap: response includes `Ratelimit-Limit` and
+ *   `Ratelimit-Remaining` headers. Recovered with a long ~60s backoff + jitter.
+ * - Global per-minute quota (RPM): those headers are absent. Recovered with a
+ *   shorter exponential backoff (1s, 2s, 4s) + jitter.
+ *
+ * If the server provides a `Retry-After` header, it takes precedence.
+ *
+ * @param maxAttempts total attempts per request (initial call + retries).
+ * @param sleepFn injectable sleep function — override in tests to avoid real delays.
+ */
+class RateLimitInterceptor(
+    private val maxAttempts: Int = 4,
+    private val sleepFn: (Long) -> Unit = { ms -> Thread.sleep(ms) }
+) : Interceptor {
+
+    override fun intercept(chain: Interceptor.Chain): Response {
+        val request = chain.request()
+        var attempt = 0
+        var response: Response = chain.proceed(request)
+
+        while (response.code == HTTP_TOO_MANY_REQUESTS && attempt < maxAttempts - 1) {
+            attempt++
+            // Only retry idempotent methods to avoid duplicating non-idempotent requests
+            // (e.g., POST multipart uploads may be non-repeatable and cause side-effects).
+            val method = request.method.uppercase()
+            if (method !in RETRYABLE_METHODS) {
+                println("[PhraseAppNetwork] HTTP 429 received on non-retryable method $method - not retrying")
+                break
+            }
+            val isConcurrent = response.header(HEADER_RATELIMIT_LIMIT) != null
+                    && response.header(HEADER_RATELIMIT_REMAINING) != null
+            val retryAfterMs = response.header(HEADER_RETRY_AFTER)
+                ?.toLongOrNull()
+                ?.let { it * 1000L }
+            val backoffMs = (retryAfterMs ?: computeBackoff(isConcurrent, attempt)).coerceAtLeast(0L)
+
+            val limitType = if (isConcurrent) "concurrent cap" else "global RPM"
+            println(
+                "[PhraseAppNetwork] HTTP 429 received ($limitType) on ${request.method} ${request.url} - " +
+                        "retry $attempt/${maxAttempts - 1} in ${backoffMs}ms"
+            )
+
+            // Free the connection before sleeping.
+            response.close()
+
+            try {
+                sleepFn(backoffMs)
+            } catch (e: InterruptedException) {
+                // Restore interrupt flag and wrap into an IOException so callers of OkHttp
+                // interceptors receive an IO-related exception (conventional behavior).
+                Thread.currentThread().interrupt()
+                val ioe = java.io.InterruptedIOException("Sleep interrupted during rate-limit backoff")
+                ioe.initCause(e)
+                throw ioe
+            }
+
+            response = chain.proceed(request)
+        }
+
+        if (response.code == HTTP_TOO_MANY_REQUESTS) {
+            println(
+                "[PhraseAppNetwork] HTTP 429 still returned after $maxAttempts attempts on " +
+                        "${request.method} ${request.url} - giving up"
+            )
+        }
+
+        return response
+    }
+
+    private fun computeBackoff(isConcurrent: Boolean, attempt: Int): Long {
+        return if (isConcurrent) {
+            // Long fixed backoff (~60s) with ±10% jitter.
+            val base = 60_000L
+            val jitter = (base * 0.1).toLong()
+            base + Random.nextLong(-jitter, jitter + 1)
+        } else {
+            // Exponential 1s, 2s, 4s, ... with ±50% jitter, capped to avoid overflow and
+            // extremely long sleeps when `attempt` is large. Cap to MAX_GLOBAL_BACKOFF_MS.
+            val maxGlobalBackoff = MAX_GLOBAL_BACKOFF_MS
+            // Compute exponential base safely using Long and cap it.
+            val raw = try {
+                // Use Double pow but guard against Infinity.
+                val v = 1_000.0 * 2.0.pow((attempt - 1).coerceAtLeast(0))
+                if (v.isFinite()) v.toLong() else maxGlobalBackoff
+            } catch (_: Exception) {
+                maxGlobalBackoff
+            }
+            val base = raw.coerceAtMost(maxGlobalBackoff)
+            val jitter = (base * 0.5).toLong().coerceAtLeast(1L)
+            base + Random.nextLong(-jitter, jitter + 1)
+        }
+    }
+
+    companion object {
+        private const val HTTP_TOO_MANY_REQUESTS = 429
+        private const val HEADER_RATELIMIT_LIMIT = "Ratelimit-Limit"
+        private const val HEADER_RATELIMIT_REMAINING = "Ratelimit-Remaining"
+        private const val HEADER_RETRY_AFTER = "Retry-After"
+        private const val MAX_GLOBAL_BACKOFF_MS = 30_000L
+        private val RETRYABLE_METHODS = setOf("GET", "HEAD", "OPTIONS")
+    }
+}
+
+
+

--- a/client/src/test/kotlin/phraseapp/network/PhraseAppNetworkDataSourceImplTest.kt
+++ b/client/src/test/kotlin/phraseapp/network/PhraseAppNetworkDataSourceImplTest.kt
@@ -1,0 +1,182 @@
+package phraseapp.network
+
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.runBlocking
+import okhttp3.MediaType.Companion.toMediaTypeOrNull
+import okhttp3.MultipartBody
+import okhttp3.RequestBody
+import okhttp3.ResponseBody
+import okhttp3.ResponseBody.Companion.toResponseBody
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import phraseapp.network.mock.MockPhraseAppService
+import java.util.concurrent.atomic.AtomicInteger
+
+/**
+ * Tests for [PhraseAppNetworkDataSourceImpl] focused on the concurrency Semaphore behaviour and
+ * the constructor parameter propagation added to fix Phrase API HTTP 429 errors.
+ */
+class PhraseAppNetworkDataSourceImplTest {
+
+    // ──────────────────────────────────────────────────────────────────────────────
+    // Existing constructor — default concurrency (maxConcurrentDownloads = 1)
+    // ──────────────────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `should use default concurrency of 1 when no maxConcurrentDownloads is specified`() =
+        runBlocking {
+            val maxConcurrent = AtomicInteger(0)
+            val peakConcurrent = AtomicInteger(0)
+            val service = concurrencyTrackingService(maxConcurrent, peakConcurrent, delayMs = 50L)
+
+            val impl = PhraseAppNetworkDataSourceImpl("", "", "", service)
+            impl.downloadAllLocales()
+
+            assertEquals(
+                "Default concurrency should be 1 — peak concurrent was ${peakConcurrent.get()}",
+                1, peakConcurrent.get()
+            )
+        }
+
+    // ──────────────────────────────────────────────────────────────────────────────
+    // Explicit concurrency = 1 (recommended for CI with multiple parallel builds)
+    // ──────────────────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `should never exceed 1 concurrent download when maxConcurrentDownloads is 1`() =
+        runBlocking {
+            val maxConcurrent = AtomicInteger(0)
+            val peakConcurrent = AtomicInteger(0)
+            val service = concurrencyTrackingService(maxConcurrent, peakConcurrent, delayMs = 50L)
+
+            val impl = PhraseAppNetworkDataSourceImpl("", "", "", service, maxConcurrentDownloads = 1)
+            impl.downloadAllLocales()
+
+            assertEquals(
+                "maxConcurrentDownloads=1 — peak concurrent was ${peakConcurrent.get()}",
+                1, peakConcurrent.get()
+            )
+        }
+
+    // ──────────────────────────────────────────────────────────────────────────────
+    // Explicit concurrency = 2 (useful when fewer parallel CI builds)
+    // ──────────────────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `should allow up to 2 concurrent downloads when maxConcurrentDownloads is 2`() =
+        runBlocking {
+            val maxConcurrent = AtomicInteger(0)
+            val peakConcurrent = AtomicInteger(0)
+            val service = concurrencyTrackingService(maxConcurrent, peakConcurrent, delayMs = 100L)
+
+            val impl = PhraseAppNetworkDataSourceImpl("", "", "", service, maxConcurrentDownloads = 2)
+            impl.downloadAllLocales()
+
+            assertTrue(
+                "maxConcurrentDownloads=2 — peak concurrent should be ≤2 but was ${peakConcurrent.get()}",
+                peakConcurrent.get() <= 2
+            )
+            assertTrue(
+                "maxConcurrentDownloads=2 — peak concurrent should be ≥2 (3 locales, enough overlap) but was ${peakConcurrent.get()}",
+                peakConcurrent.get() >= 2
+            )
+        }
+
+    @Test
+    fun `should never exceed the configured maxConcurrentDownloads limit`() = runBlocking {
+        val maxConcurrent = AtomicInteger(0)
+        val peakConcurrent = AtomicInteger(0)
+        // Use a 3-locale service to stress the concurrency limit
+        val service = concurrencyTrackingService(maxConcurrent, peakConcurrent, delayMs = 50L)
+
+        for (limit in 1..3) {
+            maxConcurrent.set(0)
+            peakConcurrent.set(0)
+            val impl =
+                PhraseAppNetworkDataSourceImpl("", "", "", service, maxConcurrentDownloads = limit)
+            impl.downloadAllLocales()
+            assertTrue(
+                "limit=$limit — peak was ${peakConcurrent.get()} which exceeds the configured limit",
+                peakConcurrent.get() <= limit
+            )
+        }
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────────
+    // Edge cases
+    // ──────────────────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `should clamp maxConcurrentDownloads to 1 when 0 is passed`() = runBlocking {
+        // Internal coerceAtLeast(1) prevents illegal Semaphore(0) construction
+        val service = MockPhraseAppService()
+        val impl = PhraseAppNetworkDataSourceImpl("", "", "", service, maxConcurrentDownloads = 0)
+        // Should complete without throwing
+        val result = impl.downloadAllLocales()
+        assertTrue(result.isNotEmpty())
+    }
+
+    @Test
+    fun `should return all locales regardless of concurrency setting`() = runBlocking {
+        val service = MockPhraseAppService()
+
+        for (limit in listOf(1, 2, 4)) {
+            val result = PhraseAppNetworkDataSourceImpl("", "", "", service, maxConcurrentDownloads = limit)
+                .downloadAllLocales()
+            assertEquals(
+                "All 3 locales must be downloaded regardless of concurrency limit=$limit",
+                3, result.size
+            )
+        }
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────────
+    // Helper — wraps the mock service with concurrency instrumentation
+    // ──────────────────────────────────────────────────────────────────────────────
+
+    /**
+     * Returns a [PhraseAppService] that delegates to [MockPhraseAppService] while tracking
+     * the number of in-flight `download` calls to measure peak concurrency.
+     */
+    private fun concurrencyTrackingService(
+        current: AtomicInteger,
+        peak: AtomicInteger,
+        delayMs: Long
+    ): PhraseAppService = object : PhraseAppService {
+        private val delegate = MockPhraseAppService()
+
+        override suspend fun getLocales(authorization: String, projectId: String) =
+            delegate.getLocales(authorization, projectId)
+
+        override suspend fun download(
+            authorization: String,
+            projectId: String,
+            localeId: String,
+            fileFormat: String,
+            placeHolder: Boolean
+        ): ResponseBody {
+            val active = current.incrementAndGet()
+            // Update peak atomically
+            peak.getAndUpdate { prev -> maxOf(prev, active) }
+            try {
+                delay(delayMs)
+                return delegate.download(authorization, projectId, localeId, fileFormat, placeHolder)
+            } finally {
+                current.decrementAndGet()
+            }
+        }
+
+        override suspend fun upload(
+            authorization: String,
+            projectId: String,
+            file: MultipartBody.Part,
+            localeId: RequestBody,
+            fileFormat: RequestBody,
+            updateTranslations: RequestBody,
+            updateDescriptions: RequestBody,
+            skipUploadTags: RequestBody
+        ): ResponseBody = "".toResponseBody("text/xml".toMediaTypeOrNull())
+    }
+}
+

--- a/client/src/test/kotlin/phraseapp/network/RateLimitInterceptorTest.kt
+++ b/client/src/test/kotlin/phraseapp/network/RateLimitInterceptorTest.kt
@@ -1,0 +1,254 @@
+package phraseapp.network
+
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * Tests for [RateLimitInterceptor].
+ *
+ * MockWebServer is used to simulate the Phrase API responses.
+ * The `sleepFn` is injected as a no-op so tests don't actually wait for backoff delays.
+ *
+ * Phrase signals two kinds of 429:
+ * - Concurrent cap: includes `Ratelimit-Limit` + `Ratelimit-Remaining` headers → ~60s backoff
+ * - Global RPM limit: those headers are absent → exponential short backoff
+ */
+class RateLimitInterceptorTest {
+
+    private val server = MockWebServer()
+    private val recordedSleepMs = mutableListOf<Long>()
+    private val noOpSleep: (Long) -> Unit = { ms -> recordedSleepMs.add(ms) }
+
+    private fun client(maxAttempts: Int = 4) = OkHttpClient.Builder()
+        .addInterceptor(RateLimitInterceptor(maxAttempts = maxAttempts, sleepFn = noOpSleep))
+        .build()
+
+    private fun get() = Request.Builder().url(server.url("/")).build()
+
+    @Before
+    fun setUp() {
+        server.start()
+        recordedSleepMs.clear()
+    }
+
+    @After
+    fun tearDown() {
+        server.shutdown()
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────────
+    // Happy path — no 429
+    // ──────────────────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `should pass through and not retry when response is 200`() {
+        server.enqueue(MockResponse().setResponseCode(200))
+
+        val response = client().newCall(get()).execute()
+
+        assertEquals(200, response.code)
+        assertEquals(1, server.requestCount)
+        assertEquals(0, recordedSleepMs.size)
+    }
+
+    @Test
+    fun `should pass through and not retry on 500`() {
+        server.enqueue(MockResponse().setResponseCode(500))
+
+        val response = client().newCall(get()).execute()
+
+        assertEquals(500, response.code)
+        assertEquals(1, server.requestCount)
+        assertEquals(0, recordedSleepMs.size)
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────────
+    // Global RPM limit (no Ratelimit headers)
+    // ──────────────────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `should retry once and succeed when global 429 is followed by 200`() {
+        server.enqueue(MockResponse().setResponseCode(429))
+        server.enqueue(MockResponse().setResponseCode(200))
+
+        val response = client().newCall(get()).execute()
+
+        assertEquals(200, response.code)
+        assertEquals(2, server.requestCount)
+        assertEquals(1, recordedSleepMs.size)
+    }
+
+    @Test
+    fun `should retry multiple times and succeed when multiple global 429 precede 200`() {
+        server.enqueue(MockResponse().setResponseCode(429))
+        server.enqueue(MockResponse().setResponseCode(429))
+        server.enqueue(MockResponse().setResponseCode(200))
+
+        val response = client(maxAttempts = 4).newCall(get()).execute()
+
+        assertEquals(200, response.code)
+        assertEquals(3, server.requestCount)
+        assertEquals(2, recordedSleepMs.size)
+    }
+
+    @Test
+    fun `should apply exponential-like backoff for global RPM 429 — each delay strictly positive`() {
+        // 3 consecutive 429s then success → 3 sleeps
+        repeat(3) { server.enqueue(MockResponse().setResponseCode(429)) }
+        server.enqueue(MockResponse().setResponseCode(200))
+
+        client(maxAttempts = 5).newCall(get()).execute()
+
+        assertEquals(3, recordedSleepMs.size)
+        recordedSleepMs.forEach { ms ->
+            assertTrue("Expected positive backoff, got $ms ms", ms > 0)
+        }
+    }
+
+    @Test
+    fun `should return 429 and stop retrying after maxAttempts exhausted`() {
+        // Queue more 429s than maxAttempts (3 total: 1 initial + 2 retries)
+        repeat(5) { server.enqueue(MockResponse().setResponseCode(429)) }
+
+        val response = client(maxAttempts = 3).newCall(get()).execute()
+
+        assertEquals(429, response.code)
+        // maxAttempts=3 → 1 initial + 2 retries = 3 requests
+        assertEquals(3, server.requestCount)
+        assertEquals(2, recordedSleepMs.size)
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────────
+    // Concurrent cap (Ratelimit-Limit + Ratelimit-Remaining headers present)
+    // ──────────────────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `should retry and succeed when concurrent 429 (with headers) is followed by 200`() {
+        server.enqueue(
+            MockResponse()
+                .setResponseCode(429)
+                .addHeader("Ratelimit-Limit", "50")
+                .addHeader("Ratelimit-Remaining", "0")
+        )
+        server.enqueue(MockResponse().setResponseCode(200))
+
+        val response = client().newCall(get()).execute()
+
+        assertEquals(200, response.code)
+        assertEquals(2, server.requestCount)
+        assertEquals(1, recordedSleepMs.size)
+    }
+
+    @Test
+    fun `should apply long backoff (~60s range) for concurrent cap 429`() {
+        server.enqueue(
+            MockResponse()
+                .setResponseCode(429)
+                .addHeader("Ratelimit-Limit", "50")
+                .addHeader("Ratelimit-Remaining", "0")
+        )
+        server.enqueue(MockResponse().setResponseCode(200))
+
+        client().newCall(get()).execute()
+
+        assertEquals(1, recordedSleepMs.size)
+        val sleepMs = recordedSleepMs.first()
+        // Expected ~60s ±10% jitter → 54_000..66_000 ms
+        assertTrue("Expected concurrent backoff ~60s but got ${sleepMs}ms", sleepMs in 54_000L..66_000L)
+    }
+
+    @Test
+    fun `should apply short backoff (below 10s) for global RPM 429`() {
+        server.enqueue(MockResponse().setResponseCode(429)) // no Ratelimit headers
+        server.enqueue(MockResponse().setResponseCode(200))
+
+        client().newCall(get()).execute()
+
+        assertEquals(1, recordedSleepMs.size)
+        val sleepMs = recordedSleepMs.first()
+        // attempt=1 → base=1s ±50% jitter → max 1500ms
+        assertTrue("Expected short exponential backoff (<10s) but got ${sleepMs}ms", sleepMs <= 10_000L)
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────────
+    // Retry-After header
+    // ──────────────────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `should use Retry-After header value when present`() {
+        server.enqueue(
+            MockResponse()
+                .setResponseCode(429)
+                .addHeader("Retry-After", "30") // 30 seconds
+        )
+        server.enqueue(MockResponse().setResponseCode(200))
+
+        client().newCall(get()).execute()
+
+        assertEquals(1, recordedSleepMs.size)
+        assertEquals(30_000L, recordedSleepMs.first())
+    }
+
+    @Test
+    fun `should use Retry-After over concurrent cap backoff when both are present`() {
+        server.enqueue(
+            MockResponse()
+                .setResponseCode(429)
+                .addHeader("Retry-After", "5")
+                .addHeader("Ratelimit-Limit", "50")
+                .addHeader("Ratelimit-Remaining", "0")
+        )
+        server.enqueue(MockResponse().setResponseCode(200))
+
+        client().newCall(get()).execute()
+
+        assertEquals(1, recordedSleepMs.size)
+        assertEquals(5_000L, recordedSleepMs.first())
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────────
+    // Header distinction: concurrent cap requires BOTH headers
+    // ──────────────────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `should apply global backoff when only Ratelimit-Limit header is present (not concurrent)`() {
+        server.enqueue(
+            MockResponse()
+                .setResponseCode(429)
+                .addHeader("Ratelimit-Limit", "50") // only one of the two headers
+        )
+        server.enqueue(MockResponse().setResponseCode(200))
+
+        client().newCall(get()).execute()
+
+        // Short backoff expected (global RPM), not the 60s concurrent backoff
+        val sleepMs = recordedSleepMs.first()
+        assertTrue("Expected global (short) backoff but got ${sleepMs}ms", sleepMs <= 10_000L)
+    }
+
+    @Test
+    fun `should apply global backoff when only Ratelimit-Remaining header is present (not concurrent)`() {
+        server.enqueue(
+            MockResponse()
+                .setResponseCode(429)
+                .addHeader("Ratelimit-Remaining", "0") // only one of the two headers
+        )
+        server.enqueue(MockResponse().setResponseCode(200))
+
+        client().newCall(get()).execute()
+
+        val sleepMs = recordedSleepMs.first()
+        assert(sleepMs <= 10_000L) {
+            "Expected global (short) backoff but got ${sleepMs}ms"
+        }
+    }
+}
+
+

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -18,6 +18,8 @@ google-gson = { group = "com.google.code.gson", name = "gson", version.ref = "go
 square-okhttp-bom = { group = "com.squareup.okhttp3", name = "okhttp-bom", version.ref = "square-okhttp" }
 square-okhttp = { group = "com.squareup.okhttp3", name = "okhttp" }
 square-okhttp-logging-interceptor = { group = "com.squareup.okhttp3", name = "logging-interceptor" }
+square-okhttp-mockwebserver = { group = "com.squareup.okhttp3", name = "mockwebserver" }
+kotlinx-coroutines-test = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-test", version.ref = "kotlinx-coroutines" }
 square-retrofit = { group = "com.squareup.retrofit2", name = "retrofit", version.ref = "square-retrofit" }
 square-retrofit-converter-gson = { group = "com.squareup.retrofit2", name = "converter-gson", version.ref = "square-retrofit" }
 mockito-kotlin = { group = "org.mockito.kotlin", name = "mockito-kotlin", version.ref = "mockito-kotlin" }


### PR DESCRIPTION
This pull request introduces configurable concurrency for downloading translations from the Phrase API, addressing issues with HTTP 429 (Too Many Requests) errors in CI environments. The key changes include adding a `maxConcurrentDownloads` setting (defaulting to 1) throughout the Gradle plugin and client, implementing a semaphore-based concurrency limit, and introducing a robust OkHttp interceptor to handle Phrase API rate limiting. Comprehensive tests are added to verify the new concurrency controls.

**Concurrency and Rate Limiting Improvements**

* Added a new `maxConcurrentDownloads` property to `PhraseExtension` and `DownloadTask`, with a default of 1, to control the number of concurrent download requests and reduce the risk of hitting Phrase's concurrent request cap. This property is now propagated throughout the Gradle plugin and client. [[1]](diffhunk://#diff-a084ba18deaa344027f1e329c3dd93e7600852fa692bf487b9f18ed5bbd6850bR85-R90) [[2]](diffhunk://#diff-a084ba18deaa344027f1e329c3dd93e7600852fa692bf487b9f18ed5bbd6850bR103) [[3]](diffhunk://#diff-1a6e65e44a61bbf0df59e5fe6fec6454940350c37cb15cd100529350beaa2364R39) [[4]](diffhunk://#diff-4d1e5b01cb2d7955fd86a9af6cbb86d8600a93f43190b5e13dad1cec6819b0cfR54-R63) [[5]](diffhunk://#diff-4d1e5b01cb2d7955fd86a9af6cbb86d8600a93f43190b5e13dad1cec6819b0cfL70-R75) [[6]](diffhunk://#diff-bda20b59d8797c45e6447b1c6fdfb62be783c75096760765be3a1e587c900be8R17) [[7]](diffhunk://#diff-bda20b59d8797c45e6447b1c6fdfb62be783c75096760765be3a1e587c900be8L31-R43)
* The `PhraseAppNetworkDataSourceImpl` class now uses a `Semaphore` to enforce the concurrency limit during locale downloads, replacing the previous chunked/throttled approach. The concurrency limit is clamped to at least 1 to avoid illegal states. [[1]](diffhunk://#diff-38e3cd5c68837334451021f562f443738e20fa424046cce977b7b43c736e12d2L6-R7) [[2]](diffhunk://#diff-38e3cd5c68837334451021f562f443738e20fa424046cce977b7b43c736e12d2L17-R28) [[3]](diffhunk://#diff-38e3cd5c68837334451021f562f443738e20fa424046cce977b7b43c736e12d2L38-R44) [[4]](diffhunk://#diff-38e3cd5c68837334451021f562f443738e20fa424046cce977b7b43c736e12d2L70-L77)

**Rate Limiting Handling**

* Introduced a new `RateLimitInterceptor` for OkHttp, which detects HTTP 429 responses and applies appropriate backoff strategies (fixed or exponential with jitter) based on Phrase's concurrent and global rate limits. It respects the `Retry-After` header when present.
* The interceptor is now included in the OkHttp client construction in `PhraseAppNetworkDataSource`.

**Testing Enhancements**

* Added a new test suite (`PhraseAppNetworkDataSourceImplTest`) to verify that the concurrency limit is respected and that the implementation behaves correctly under various concurrency settings and edge cases.
* Added test dependencies for OkHttp MockWebServer and Kotlin coroutines test support.

These changes make the plugin more robust in CI environments and provide flexibility for users to tune concurrency as needed.